### PR TITLE
fix: allow reference sub-factories in SelfAttribute

### DIFF
--- a/async_factory_boy/factory/sqlalchemy.py
+++ b/async_factory_boy/factory/sqlalchemy.py
@@ -3,7 +3,7 @@ import inspect
 from inspect import isawaitable
 from typing import Any, Optional
 
-from factory import errors, Factory, FactoryError
+from factory import BUILD_STRATEGY, errors, Factory, FactoryError
 from factory.alchemy import SQLAlchemyOptions
 from factory.builder import (BuildStep, DeclarationSet, parse_declarations, Resolver, StepBuilder)
 from sqlalchemy import select
@@ -113,6 +113,14 @@ class AsyncSQLAlchemyFactory(Factory):
 
         step = AsyncStepBuilder(cls._meta, params, strategy)
         return await step.build()
+
+    @classmethod
+    async def build(cls, **kwargs):
+        return await cls._generate(strategy=BUILD_STRATEGY, params=kwargs)
+
+    @classmethod
+    async def build_batch(cls, size, **kwargs):
+        return [await cls.build(**kwargs) for _ in range(size)]
 
     @classmethod
     async def create(cls, **kwargs):

--- a/async_factory_boy/factory/sqlalchemy.py
+++ b/async_factory_boy/factory/sqlalchemy.py
@@ -175,9 +175,10 @@ class AsyncSQLAlchemyFactory(Factory):
                 if get_or_create_params:
                     try:
                         obj = (
-                            await session.execute(select(model_class).filter_by(**get_or_create_params))).scalars(
-
-                        ).one()
+                            await session
+                            .execute(select(model_class)
+                            .filter_by(**get_or_create_params))
+                        ).scalars().one()
                     except NoResultFound:
                         # Original params are not a valid lookup and triggered a create(),
                         # that resulted in an IntegrityError.

--- a/async_factory_boy/factory/sqlalchemy.py
+++ b/async_factory_boy/factory/sqlalchemy.py
@@ -1,7 +1,7 @@
 import asyncio
 import inspect
 from inspect import isawaitable
-from typing import Any
+from typing import Any, Optional
 
 from factory import errors, Factory, FactoryError
 from factory.alchemy import SQLAlchemyOptions
@@ -36,7 +36,7 @@ class AsyncBuildStep(BuildStep):
 class AsyncStepBuilder(StepBuilder):
     async def build(
         self,
-        parent_step: AsyncBuildStep | None = None,  # type: ignore[override]
+        parent_step: Optional[AsyncBuildStep] = None,  # type: ignore[override]
         force_sequence: Any = None,
     ) -> Any:
         """Build a factory instance."""

--- a/async_factory_boy/factory/sqlalchemy.py
+++ b/async_factory_boy/factory/sqlalchemy.py
@@ -1,21 +1,118 @@
 import asyncio
 import inspect
+from inspect import isawaitable
+from typing import Any
 
-from factory import Factory, FactoryError
+from factory import errors, Factory, FactoryError
 from factory.alchemy import SQLAlchemyOptions
+from factory.builder import (BuildStep, DeclarationSet, parse_declarations, Resolver, StepBuilder)
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
+
+
+class AsyncResolver(Resolver):
+    async def async_get(self, name: str) -> Any:
+        """Get a value from the stub, resolving async values."""
+        value = getattr(self, name)
+        if isawaitable(value):
+            value = await value
+            self._Resolver__values[name] = value
+
+        return value
+
+
+class AsyncBuildStep(BuildStep):
+    async def resolve(self, declarations: DeclarationSet) -> None:  # type: ignore[override]
+        self.stub = AsyncResolver(
+            declarations=declarations,
+            step=self,
+            sequence=self.sequence,
+        )
+
+        for field_name in declarations:
+            self.attributes[field_name] = await self.stub.async_get(field_name)
+
+
+class AsyncStepBuilder(StepBuilder):
+    async def build(
+        self,
+        parent_step: AsyncBuildStep | None = None,  # type: ignore[override]
+        force_sequence: Any = None,
+    ) -> Any:
+        """Build a factory instance."""
+        # This method is a copy-paste from the original StepBuilder.build method
+        # with the only difference that the AsyncBuildStep is used instead of BuildStep
+        # and the resolve method is awaited.
+
+        pre, post = parse_declarations(
+            self.extras,
+            base_pre=self.factory_meta.pre_declarations,
+            base_post=self.factory_meta.post_declarations,
+        )
+
+        if force_sequence is not None:
+            sequence = force_sequence
+        elif self.force_init_sequence is not None:
+            sequence = self.force_init_sequence
+        else:
+            sequence = self.factory_meta.next_sequence()
+
+        # The next line was changed:
+        step = AsyncBuildStep(
+            builder=self,
+            sequence=sequence,
+            parent_step=parent_step,
+        )
+        # The next line was changed:
+        await step.resolve(pre)
+
+        args, kwargs = self.factory_meta.prepare_arguments(step.attributes)
+
+        instance = self.factory_meta.instantiate(
+            step=step,
+            args=args,
+            kwargs=kwargs,
+        )
+
+        # The next two lines were added:
+        if inspect.isawaitable(instance):
+            instance = await instance
+
+        postgen_results = {}
+        for declaration_name in post.sorted():
+            declaration = post[declaration_name]
+            postgen_results[
+                declaration_name] = declaration.declaration.evaluate_post(
+                instance=instance,
+                step=step,
+                overrides=declaration.context,
+            )
+        self.factory_meta.use_postgeneration_results(
+            instance=instance,
+            step=step,
+            results=postgen_results,
+        )
+        return instance
 
 
 class AsyncSQLAlchemyFactory(Factory):
     _options_class = SQLAlchemyOptions
 
     @classmethod
-    def _generate(cls, strategy, params):
+    async def _generate(cls, strategy, params):
         # Original params are used in _get_or_create if it cannot build an
         # object initially due to an IntegrityError being raised
         cls._original_params = params
-        return super()._generate(strategy, params)
+
+        if cls._meta.abstract:
+            raise errors.FactoryError(
+                "Cannot generate instances of abstract factory {f}; "
+                "Ensure {f}.Meta.model is set and {f}.Meta.abstract "
+                "is either not set or False.".format(**dict(f=cls.__name__)),
+            )
+
+        step = AsyncStepBuilder(cls._meta, params, strategy)
+        return await step.build()
 
     @classmethod
     async def create(cls, **kwargs):
@@ -77,7 +174,10 @@ class AsyncSQLAlchemyFactory(Factory):
                 }
                 if get_or_create_params:
                     try:
-                        obj = (await session.execute(select(model_class).filter_by(**get_or_create_params))).scalars().one()
+                        obj = (
+                            await session.execute(select(model_class).filter_by(**get_or_create_params))).scalars(
+
+                        ).one()
                     except NoResultFound:
                         # Original params are not a valid lookup and triggered a create(),
                         # that resulted in an IntegrityError.

--- a/tests/sqlalchemy/factory.py
+++ b/tests/sqlalchemy/factory.py
@@ -1,7 +1,6 @@
 import factory
 
 from async_factory_boy.factory.sqlalchemy import AsyncSQLAlchemyFactory
-
 from . import models
 from .conftest import sc_session
 
@@ -66,3 +65,25 @@ class WithMultipleGetOrCreateFieldsFactory(AsyncSQLAlchemyFactory):
     id = factory.Sequence(lambda n: n)
     slug = factory.Sequence(lambda n: "slug%s" % n)
     text = factory.Sequence(lambda n: "text%s" % n)
+
+
+class ParentModelFactory(AsyncSQLAlchemyFactory):
+    class Meta:
+        model = models.ParentModel
+        sqlalchemy_session = sc_session
+        sqlalchemy_session_persistence = "commit"
+
+    id = factory.Sequence(lambda n: n)
+    name = factory.Sequence(lambda n: "name%d" % n)
+
+
+class ChildModelWithSelfAttributeFactory(AsyncSQLAlchemyFactory):
+    class Meta:
+        model = models.ChildModel
+        sqlalchemy_session = sc_session
+        sqlalchemy_session_persistence = "commit"
+
+    id = factory.Sequence(lambda n: n)
+    name = factory.Sequence(lambda n: "name%d" % n)
+    parent = factory.SubFactory(ParentModelFactory)
+    parent_name = factory.SelfAttribute("parent.name")

--- a/tests/sqlalchemy/models.py
+++ b/tests/sqlalchemy/models.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Column, Integer, Unicode
+from sqlalchemy import Column, ForeignKey, Integer, Unicode
 from sqlalchemy.ext.declarative import declarative_base
-
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
@@ -40,3 +40,21 @@ class SpecialFieldModel(Base):
 
     id = Column(Integer(), primary_key=True)
     session = Column(Unicode(20))
+
+
+class ParentModel(Base):
+    __tablename__ = "ParentModelTable"
+
+    id = Column(Integer(), primary_key=True)
+    name = Column(Unicode(20))
+    children = relationship('ChildModel', back_populates='parent')
+
+
+class ChildModel(Base):
+    __tablename__ = "ChildModelTable"
+
+    id = Column(Integer(), primary_key=True)
+    name = Column(Unicode(20))
+    parent_id = Column(ForeignKey('ParentModelTable.id'))
+    parent = relationship('ParentModel')
+    parent_name = Column(Unicode(20))

--- a/tests/sqlalchemy/test_sqlalchemy.py
+++ b/tests/sqlalchemy/test_sqlalchemy.py
@@ -32,6 +32,12 @@ class TestSQLAlchemyPkSequence:
         assert 'foo1' == std1.foo
         assert 'foo2' == std2.foo
 
+    async def test_pk_many_batch(self):
+        stds = await StandardFactory.build_batch(3)
+        assert 'foo1' == stds[0].foo
+        assert 'foo2' == stds[1].foo
+        assert 'foo3' == stds[2].foo
+
     async def test_pk_creation(self):
         std1 = await StandardFactory.create()
         assert 'foo1' == std1.foo
@@ -41,6 +47,12 @@ class TestSQLAlchemyPkSequence:
         std2 = await StandardFactory.create()
         assert 'foo0' == std2.foo
         assert 0 == std2.id
+
+    async def test_pk_creation_batch(self):
+        stds = await StandardFactory.create_batch(3)
+        assert 'foo1' == stds[0].foo
+        assert 'foo2' == stds[1].foo
+        assert 'foo3' == stds[2].foo
 
     async def test_pk_force_value(self):
         std1 = await StandardFactory.create(id=10)

--- a/tests/sqlalchemy/test_sqlalchemy.py
+++ b/tests/sqlalchemy/test_sqlalchemy.py
@@ -72,8 +72,12 @@ class TestSQLAlchemyGetOrCreate:
         assert 2 == len(set(objs))
 
         result = (
-            await db_session.execute(sqlalchemy.select(MultiFieldModel.slug).order_by(
-                MultiFieldModel.slug))).scalars().all()
+            await db_session.execute(
+                sqlalchemy
+                .select(MultiFieldModel.slug)
+                .order_by(MultiFieldModel.slug)
+            )
+        ).scalars().all()
         assert list(result) == ["alt", "main"]
 
 

--- a/tests/sqlalchemy/test_sqlalchemy.py
+++ b/tests/sqlalchemy/test_sqlalchemy.py
@@ -4,9 +4,9 @@ import sqlalchemy
 from factory import FactoryError, Iterator
 
 from async_factory_boy.factory.sqlalchemy import AsyncSQLAlchemyFactory
-
 from .conftest import sc_session
 from .factory import (
+    ChildModelWithSelfAttributeFactory,
     MultifieldModelFactory,
     NonIntegerPkFactory,
     NoSessionFactory,
@@ -23,12 +23,12 @@ class TestSQLAlchemyPkSequence:
         StandardFactory.reset_sequence(1)
 
     async def test_pk_first(self):
-        std = StandardFactory.build()
+        std = await StandardFactory.build()
         assert 'foo1' == std.foo
 
     async def test_pk_many(self):
-        std1 = StandardFactory.build()
-        std2 = StandardFactory.build()
+        std1 = await StandardFactory.build()
+        std2 = await StandardFactory.build()
         assert 'foo1' == std1.foo
         assert 'foo2' == std2.foo
 
@@ -71,7 +71,9 @@ class TestSQLAlchemyGetOrCreate:
         assert 6 == len(objs)
         assert 2 == len(set(objs))
 
-        result = (await db_session.execute(sqlalchemy.select(MultiFieldModel.slug).order_by(MultiFieldModel.slug))).scalars().all()
+        result = (
+            await db_session.execute(sqlalchemy.select(MultiFieldModel.slug).order_by(
+                MultiFieldModel.slug))).scalars().all()
         assert list(result) == ["alt", "main"]
 
 
@@ -99,12 +101,12 @@ class TestSQLAlchemyNonIntegerPk:
         NonIntegerPkFactory.reset_sequence()
 
     async def test_first(self):
-        nonint = NonIntegerPkFactory.build()
+        nonint = await NonIntegerPkFactory.build()
         assert 'foo0' == nonint.id
 
     async def test_many(self):
-        nonint1 = NonIntegerPkFactory.build()
-        nonint2 = NonIntegerPkFactory.build()
+        nonint1 = await NonIntegerPkFactory.build()
+        nonint2 = await NonIntegerPkFactory.build()
 
         assert 'foo0' == nonint1.id
         assert 'foo1' == nonint2.id
@@ -114,7 +116,7 @@ class TestSQLAlchemyNonIntegerPk:
         assert 'foo0' == nonint1.id
 
         NonIntegerPkFactory.reset_sequence()
-        nonint2 = NonIntegerPkFactory.build()
+        nonint2 = await NonIntegerPkFactory.build()
         assert 'foo0' == nonint2.id
 
     async def test_force_pk(self):
@@ -130,8 +132,8 @@ class TestSQLAlchemyNoSession:
     async def test_build_does_not_raises_exception_when_no_session_was_set(self):
         NoSessionFactory.reset_sequence()  # Make sure we start at test ID 0
 
-        inst0 = NoSessionFactory.build()
-        inst1 = NoSessionFactory.build()
+        inst0 = await NoSessionFactory.build()
+        inst1 = await NoSessionFactory.build()
         assert inst0.id == 0
         assert inst1.id == 1
 
@@ -140,6 +142,7 @@ class TestNameConflict:
     """Regression test for `TypeError: _save() got multiple values for argument 'session'`
     See #775.
     """
+
     async def test_no_name_conflict_on_save(self):
         class SpecialFieldWithSaveFactory(AsyncSQLAlchemyFactory):
             class Meta:
@@ -164,3 +167,15 @@ class TestNameConflict:
 
         get_or_created_child = await SpecialFieldWithGetOrCreateFactory()
         assert get_or_created_child.session == ""
+
+
+class TestChildModelWithSelfAttributeFactory:
+    async def test_subfactory(self):
+        child = await ChildModelWithSelfAttributeFactory.create()
+
+        assert child.id is not None
+        assert child.name is not None
+        assert child.parent_id is not None
+        assert child.parent is not None
+        assert child.parent.id is not None
+        assert child.parent.name is not None


### PR DESCRIPTION
BREAKING CHANGE:
`AsyncSQLAlchemyFactory.build()` and `AsyncSQLAlchemyFactory.build_batch()` now have to be awaited