### PR TITLE
Support type annotations

### DIFF
--- a/async_factory_boy/factory/sqlalchemy.py
+++ b/async_factory_boy/factory/sqlalchemy.py
@@ -1,13 +1,16 @@
 import asyncio
 import inspect
+from typing import List, TypeVar
 
 from factory import Factory, FactoryError
 from factory.alchemy import SQLAlchemyOptions
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
+_T = TypeVar("_T")
 
-class AsyncSQLAlchemyFactory(Factory):
+
+class AsyncSQLAlchemyFactory(Factory[_T]):
     _options_class = SQLAlchemyOptions
 
     @classmethod
@@ -18,7 +21,7 @@ class AsyncSQLAlchemyFactory(Factory):
         return super()._generate(strategy, params)
 
     @classmethod
-    async def create(cls, **kwargs):
+    async def create(cls, **kwargs) -> _T:
         session = cls._meta.sqlalchemy_session
 
         instance = await super().create(**kwargs)
@@ -47,7 +50,7 @@ class AsyncSQLAlchemyFactory(Factory):
         return asyncio.create_task(maker_coroutine())
 
     @classmethod
-    async def create_batch(cls, size, **kwargs):
+    async def create_batch(cls, size, **kwargs) -> List[_T]:
         return [await cls.create(**kwargs) for _ in range(size)]
 
     @classmethod

--- a/async_factory_boy/factory/tortoise.py
+++ b/async_factory_boy/factory/tortoise.py
@@ -1,10 +1,13 @@
 import inspect
+from typing import List, TypeVar
 
 import factory
 from factory.builder import BuildStep, StepBuilder, parse_declarations
 
+_T = TypeVar("_T")
 
-class AsyncTortoiseFactory(factory.Factory):
+
+class AsyncTortoiseFactory(factory.Factory[_T]):
     @classmethod
     async def _generate(cls, strategy, params):
         if cls._meta.abstract:
@@ -25,7 +28,7 @@ class AsyncTortoiseFactory(factory.Factory):
         return await model_class.create(*args, **kwargs)
 
     @classmethod
-    async def create_batch(cls, size, **kwargs):
+    async def create_batch(cls, size, **kwargs) -> List[_T]:
         return [await cls.create(**kwargs) for _ in range(size)]
 
     @classmethod


### PR DESCRIPTION
This lets people specify the model type for a factory and have IDEs/type-checkers infer typing.

```py
class UserFactory(AsyncSQLAlchemyFactory[User]):
    ...
```

Before in VS Code:
![Screenshot 2024-12-29 212014](https://github.com/user-attachments/assets/e11cf835-8771-447c-9c2f-503639c22637)

After:
![Screenshot 2024-12-29 212026](https://github.com/user-attachments/assets/29fdc6ee-97e7-4edb-b822-58a19d1301b2)
